### PR TITLE
Update services page layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -443,8 +443,8 @@ footer {
 }
 
 .services-list .icon {
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   stroke: #00A651; /* Match your brand green */
   flex-shrink: 0;
   margin-top: 2px;

--- a/services.html
+++ b/services.html
@@ -41,9 +41,10 @@
 </header>
 
 <main class="page">
-  <div class="container">
-    <h2>Our Services</h2>
-    <ul class="services-list">
+  <section class="about-services">
+    <div class="container">
+      <h2>Our Services</h2>
+      <ul class="services-list">
       <li>
         <svg xmlns="http://www.w3.org/2000/svg" class="icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6h4"/>
@@ -74,8 +75,9 @@
         </svg>
         <strong>Consulting & Advisory</strong> – Strategic reviews, workshops, and uplift roadmaps
       </li>
-    </ul>
-  </div>
+      </ul>
+    </div>
+  </section>
 </main>
 
 <footer>


### PR DESCRIPTION
## Summary
- wrap the services list in an `about-services` section
- enlarge service icons to 32px for clarity

## Testing
- `codex tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9ec1834c832eb69abdc879c34af2