### PR TITLE
Fix services page header

### DIFF
--- a/services.html
+++ b/services.html
@@ -27,9 +27,11 @@
 <body>
 
 <header>
-  <div class="container">
-    <h1>Titan Solutions</h1>
-    <nav>
+  <div class="nav-wrapper container">
+    <a href="/index.html">
+      <img src="/assets/Titan Solutions__Logomark.png" alt="Titan Solutions Logo" class="logo" />
+    </a>
+    <nav class="nav">
       <ul>
         <li><a href="/index.html">Home</a></li>
         <li><a href="/about/index.html">About</a></li>


### PR DESCRIPTION
## Summary
- bring services page header inline with other pages by adding the nav wrapper
  and site logo

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685aa0af41a4832e9072132f75323c9e