### PR TITLE
Remove duplicate skip links

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,7 +28,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
   <!-- HEADER / HERO -->
   <!-- MAIN CONTENT -->
   <main id="main">

--- a/blog.html
+++ b/blog.html
@@ -53,7 +53,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
   <main id="main">
     <section class="blog-list">
       <div class="container">

--- a/blog/blog-autopilot.html
+++ b/blog/blog-autopilot.html
@@ -49,7 +49,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
   <main id="main">
     <article class="blog-post">
       <div class="container">

--- a/blog/blog-intune-policies.html
+++ b/blog/blog-intune-policies.html
@@ -49,7 +49,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
 
 <main id="main">
   <article class="blog-post">

--- a/contact.html
+++ b/contact.html
@@ -38,7 +38,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
   <main id="main">
     <section class="container" style="padding: 4rem 0; text-align: center;">
       <!-- Replace this with your HubSpot embed code -->

--- a/contact/index.html
+++ b/contact/index.html
@@ -26,7 +26,6 @@
 </head>
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
 
 <header>
   <div class="container">

--- a/contact/thank-you.html
+++ b/contact/thank-you.html
@@ -46,7 +46,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
   <main id="main">
     <section class="container" style="padding: 3rem 0; text-align: center;">
       <p>If it's urgent, you can also email us at <a href="mailto:hello@titansolutions.com.au">hello@titansolutions.com.au</a></p>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
 
   <!-- HERO -->
 <main id="main">

--- a/services.html
+++ b/services.html
@@ -28,7 +28,6 @@
 
 <body>
   <div data-include="/partials/header.html"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
 
   <!-- HEADER -->
   <!-- MAIN CONTENT -->


### PR DESCRIPTION
## Summary
- deleted redundant `<a class="skip-link">` elements from all pages

## Testing
- `grep -R "skip-link" --include='*.html'`


------
https://chatgpt.com/codex/tasks/task_e_685bb2890dbc832e9b7dc30f1e6514ff