### PR TITLE
Add canonical include across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,6 +24,7 @@
   <meta name="twitter:title" content="About – Titan Solutions" />
   <meta name="twitter:description" content="Learn how Titan Solutions empowers businesses with modern endpoint and cloud‑native solutions." />
   <meta name="twitter:image" content="/assets/og-default.jpg" />
+  <div data-include="/partials/canonical.html"></div>
 </head>
 
 <body>

--- a/blog.html
+++ b/blog.html
@@ -49,6 +49,7 @@
     gtag('js', new Date());
     gtag('config', 'G-Q3NMJ4MD06');
   </script>
+  <div data-include="/partials/canonical.html"></div>
 </head>
 
 <body>

--- a/contact.html
+++ b/contact.html
@@ -34,6 +34,7 @@
 
   gtag('config', 'G-Q3NMJ4MD06');
 </script>
+  <div data-include="/partials/canonical.html"></div>
 </head>
 
 <body>

--- a/contact/index.html
+++ b/contact/index.html
@@ -23,6 +23,7 @@
   <meta name="twitter:title" content="Contact - Titan Solutions">
   <meta name="twitter:description" content="Titan Solutions helps SMBs transform their IT environment with expert Microsoft 365, Intune, and modern cloud-native strategies, offering practical, secure, and scalable solutions.">
   <meta name="twitter:image" content="/assets/og-default.jpg">
+  <div data-include="/partials/canonical.html"></div>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/contact/thank-you.html
+++ b/contact/thank-you.html
@@ -42,6 +42,7 @@
 
   gtag('config', 'G-Q3NMJ4MD06');
 </script>
+  <div data-include="/partials/canonical.html"></div>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
 
   gtag('config', 'G-Q3NMJ4MD06');
 </script>
+  <div data-include="/partials/canonical.html"></div>
 </head>
 
 <body>

--- a/services.html
+++ b/services.html
@@ -24,6 +24,7 @@
   <meta name="twitter:title" content="Services - Titan Solutions">
   <meta name="twitter:description" content="Explore modern IT services including Intune, Microsoft 365, security uplift, and advisory.">
   <meta name="twitter:image" content="/assets/og-default.jpg">
+  <div data-include="/partials/canonical.html"></div>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- include canonical partial before `</head>` on pages without explicit canonical link

## Testing
- `grep -n canonical.html -n about.html blog.html contact.html index.html services.html contact/index.html contact/thank-you.html`


------
https://chatgpt.com/codex/tasks/task_e_685bb39ae7c0832e8c9bd84843c0c501