### PR TITLE
Fix alt text for icon images

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,17 +70,17 @@
 
         <div class="service-cards">
           <div class="card">
-            <img src="assets/icon-intune.svg" alt="Intune Icon" />
+            <img src="assets/icon-intune.svg" alt="" />
             <h3>Intune Management</h3>
             <p>Modern endpoint security and provisioning using Microsoft Intune, Autopilot, and policy baselines.</p>
           </div>
           <div class="card">
-            <img src="assets/icon-m365.svg" alt="Microsoft 365 Icon" />
+            <img src="assets/icon-m365.svg" alt="" />
             <h3>Microsoft 365</h3>
             <p>Licensing, identity, security, and adoption strategies across the full Microsoft 365 platform.</p>
           </div>
           <div class="card">
-            <img src="assets/icon-consult.svg" alt="Consulting Icon" />
+            <img src="assets/icon-consult.svg" alt="" />
             <h3>IT Consulting</h3>
             <p>Advisory and implementation support for cloud migrations, device strategy, and secure workplace IT.</p>
           </div>


### PR DESCRIPTION
## Summary
- empty alt attribute for icon SVGs

## Testing
- `grep -r "assets/icon" -n --include='*.html'`

------
https://chatgpt.com/codex/tasks/task_e_685bbfd1f40c832e9efa18429e89b313