### PR TITLE
Fix image lazy loading and dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,17 +70,17 @@
 
         <div class="service-cards">
           <div class="card">
-            <img src="assets/icon-intune.svg" alt="" />
+            <img src="assets/icon-intune.svg" alt="" loading="lazy" width="70" height="70" />
             <h3>Intune Management</h3>
             <p>Modern endpoint security and provisioning using Microsoft Intune, Autopilot, and policy baselines.</p>
           </div>
           <div class="card">
-            <img src="assets/icon-m365.svg" alt="" />
+            <img src="assets/icon-m365.svg" alt="" loading="lazy" width="70" height="70" />
             <h3>Microsoft 365</h3>
             <p>Licensing, identity, security, and adoption strategies across the full Microsoft 365 platform.</p>
           </div>
           <div class="card">
-            <img src="assets/icon-consult.svg" alt="" />
+            <img src="assets/icon-consult.svg" alt="" loading="lazy" width="70" height="70" />
             <h3>IT Consulting</h3>
             <p>Advisory and implementation support for cloud migrations, device strategy, and secure workplace IT.</p>
           </div>
@@ -95,14 +95,14 @@
 
     <div class="blog-cards">
       <a href="blog/blog-autopilot.html" class="blog-card">
-        <img src="assets/blog-placeholder-1.jpg" alt="Blog Post 1">
+        <img src="assets/blog-placeholder-1.jpg" alt="Blog Post 1" loading="lazy" width="640" height="360">
         <h3>Why Autopilot is a Game-Changer for Device Deployment</h3>
         <p>Explore how Windows Autopilot simplifies device setup and user provisioning in modern workplaces.</p>
         <span class="read-more">Read More →</span>
       </a>
 
       <a href="blog/blog-intune-policies.html" class="blog-card">
-        <img src="assets/blog-placeholder-2.jpg" alt="Blog Post 2">
+        <img src="assets/blog-placeholder-2.jpg" alt="Blog Post 2" loading="lazy" width="640" height="360">
         <h3>Top 5 Intune Policies Every SMB Should Use</h3>
         <p>A practical breakdown of essential Intune settings to boost security and streamline management.</p>
         <span class="read-more">Read More →</span>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` and explicit dimensions to icons and blog images on the homepage

## Testing
- `grep -R "<img" -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685bc2cee7a8832e8bfc22909e156e1e