### PR TITLE
style: standardise CTA banner (green) & clean legacy inline strips

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,7 +19,8 @@
   </main>
 
 
-  <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js" defer></script>
   <div data-include="/partials/cta-banner.html"></div>
-</body></html> 
+
+  <div data-include="/partials/footer.html"></div>
+  </body>
+</html>

--- a/about.html
+++ b/about.html
@@ -62,17 +62,11 @@
       </div>
     </section>
 
-    <section class="cta-strip">
-      <div class="container">
-        <a href="/contact.html" class="button">Get in Touch</a>
-      </div>
-    </section>
   </main>
 
-  <!-- FOOTER -->
-  <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
   <div data-include="/partials/cta-banner.html"></div>
+
+  <div data-include="/partials/footer.html"></div>
   </body>
 
 </html>

--- a/blog.html
+++ b/blog.html
@@ -82,17 +82,11 @@
         -->
       </div>
     </section>
-    <!-- GREEN CALL TO ACTION (Optional, subtle callout strip) -->
-    <section class="cta-strip">
-      <div class="container">
-        <a href="contact.html" class="button">Get in Touch</a>
-      </div>
-    </section>
   </main>
 
-  <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
   <div data-include="/partials/cta-banner.html"></div>
+
+  <div data-include="/partials/footer.html"></div>
   </body>
 
 </html>

--- a/blog/blog-autopilot.html
+++ b/blog/blog-autopilot.html
@@ -46,6 +46,7 @@
     gtag('js', new Date());
     gtag('config', 'G-Q3NMJ4MD06');
   </script>
+  <script src="/js/includes.js" defer></script>
 </head>
 
 <body>
@@ -76,7 +77,8 @@
     </article>
   </main>
 
+  <div data-include="/partials/cta-banner.html"></div>
+
   <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
   </body>
 </html>

--- a/blog/blog-intune-policies.html
+++ b/blog/blog-intune-policies.html
@@ -46,6 +46,7 @@
     gtag('js', new Date());
     gtag('config', 'G-Q3NMJ4MD06');
   </script>
+  <script src="/js/includes.js" defer></script>
 </head>
 
 <body>
@@ -78,7 +79,8 @@
   </article>
 </main>
 
+  <div data-include="/partials/cta-banner.html"></div>
+
   <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -55,9 +55,9 @@
     </section>
   </main>
 
-  <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
   <div data-include="/partials/cta-banner.html"></div>
+
+  <div data-include="/partials/footer.html"></div>
   </body>
 
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -86,10 +86,19 @@ nav a:hover {
 
 /* === OPTIONAL CTA BANNER === */
 .cta-banner {
-  background-color: #00B6EF;
+  background-color: #87c542;
   color: #fff;
   text-align: center;
   padding: 3rem 2rem;
+}
+
+.cta-banner a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.cta-banner a:hover {
+  opacity: 0.85;
 }
 
 .cta-banner h2 {

--- a/index.html
+++ b/index.html
@@ -52,14 +52,7 @@
 
   <!-- HERO -->
 <main id="main">
-    <!-- CTA BANNER (BLUE) -->
-    <section class="cta-banner">
-      <div class="container">
-        <h2>Modern Endpoint & Cloud-Native Solutions</h2>
-        <p>Helping businesses securely modernise their Microsoft 365 environment.</p>
-        <a href="contact.html" class="button">Get in Touch</a>
-      </div>
-    </section>
+
 
     <!-- ABOUT + SERVICES -->
     <section class="about-services">
@@ -112,18 +105,12 @@
   </div>
 </section>
     
-    <!-- GREEN CALL TO ACTION (Optional, subtle callout strip) -->
-    <section class="cta-strip">
-      <div class="container">
-        <a href="contact.html" class="button">Get in Touch</a>
-      </div>
-    </section>
+
 
   </main>
 
-  <!-- FOOTER -->
-  <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
   <div data-include="/partials/cta-banner.html"></div>
+
+  <div data-include="/partials/footer.html"></div>
   </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -73,17 +73,12 @@
       </div>
     </section>
 
-    <section class="cta-strip">
-      <div class="container">
-        <a href="/contact.html" class="button">Get in Touch</a>
-      </div>
-    </section>
+
 
   </main>
 
-  <!-- FOOTER -->
-  <div data-include="/partials/footer.html"></div>
-  <script src="/js/includes.js"></script>
   <div data-include="/partials/cta-banner.html"></div>
+
+  <div data-include="/partials/footer.html"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update `.cta-banner` styles to Titan green
- remove old inline call-to-action blocks
- ensure CTA partial loads above the footer on every page
- load `includes.js` in `<head>` across blog posts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d32ae3b48832e8f9b8ec1aa526af4