### PR TITLE
fix: restore blue hero CTA banner on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,23 @@
 <body>
   <div data-include="/partials/header.html"></div>
 
+  <!-- Hero CTA banner (home page only) -->
+  <section class="cta-banner">
+    <div class="container">
+      <h1 class="cta-heading">
+        Need a hand modernising your Microsoft 365 environment?
+      </h1>
+      <p class="cta-text">
+        Book a free 30-minute discovery call with a Titan Solutions consultant.
+      </p>
+      <a href="https://bookings.titansolutions.com.au/"
+         class="btn btn-primary"
+         aria-label="Schedule a discovery call">
+        Book now
+      </a>
+    </div>
+  </section>
+
   <!-- HERO -->
 <main id="main">
 


### PR DESCRIPTION
## Summary
- restore the blue hero CTA banner only on the home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d36a0b2f0832e82e4284e8b95d2ed