### PR TITLE
Add fallback mobile navigation CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -877,3 +877,15 @@ body.notfound-page {
     gap: 2rem;
   }
 }
+
+/* ======== Fallback Mobile Navigation ======== */
+@media (max-width: 768px) {
+  .burger {
+    display: none;
+  }
+  .nav-links {
+    display: flex !important;
+    flex-direction: column;
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure navigation links remain visible when hamburger script fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686105c75294832eb0d7fbbb152ff9e4