### PR TITLE
Initialize Eleventy setup

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,15 @@
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPassthroughCopy("assets");
+  eleventyConfig.addPassthroughCopy("css");
+  eleventyConfig.addPassthroughCopy("js");
+
+  eleventyConfig.addPlugin(require("@quasibit/eleventy-plugin-sitemap"), {
+    sitemap: { hostname: "https://titansolutions.com.au" }
+  });
+
+  return {
+    dir: { input: ".", includes: "_includes", output: "_site" },
+    markdownTemplateEngine: "njk",
+    htmlTemplateEngine: "njk"
+  };
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "titan-website",
+  "version": "1.0.0",
+  "description": "Public Site for Titan Solutions - built with HTML/CSS",
+  "main": "tailwind.config.js",
+  "scripts": {
+    "build": "eleventy",
+    "start": "eleventy --serve --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- set up package.json
- add dev scripts for Eleventy
- configure basic Eleventy options
- ignore node_modules

## Testing
- `npm run build` *(fails: `eleventy: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68665739ee6c832ea92e69930c0a9be6