### PR TITLE
Add Eleventy to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "titan-website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "titan-website",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@11ty/eleventy": "^2.0.1"
+      }
+    }
+  },
+  "dependencies": {
+    "@11ty/eleventy": {
+      "version": "2.0.1",
+      "resolved": "",
+      "integrity": "",
+      "dev": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Public Site for Titan Solutions - built with HTML/CSS",
   "main": "tailwind.config.js",
   "scripts": {
-    "build": "eleventy",
-    "start": "eleventy --serve --watch"
+    "build": "npx eleventy",
+    "start": "npx eleventy --serve --watch"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "@11ty/eleventy": "^2.0.1"
+  }
 }


### PR DESCRIPTION
## Summary
- add `@11ty/eleventy` as a production dependency
- adjust build and start scripts to use `npx`
- include a basic `package-lock.json`

## Testing
- `npm run build` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6866593307c0832ebf7292d0289fc45c