### PR TITLE
Replace Calendly link with Microsoft Bookings link

### DIFF
--- a/index.html
+++ b/index.html
@@ -729,7 +729,7 @@
             Independent eyes on your IT spend. No vendor agenda.
           </p>
           <div class="hero__cta-row">
-            <a class="btn btn--primary" href="https://calendly.com/titan-solutions-advisory/discovery" id="book">
+            <a class="btn btn--primary" href="https://outlook.office365.com/owa/calendar/Advisory@titansolutions.com.au/bookings/" id="book">
               Book a Free 15-Min Call
               <svg class="btn__arrow" viewBox="0 0 18 18" fill="none" aria-hidden="true">
                 <path d="M3 9h12M10 4l5 5-5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
@@ -925,7 +925,7 @@
         </div>
 
         <div class="invest-cta-row">
-          <a class="btn btn--primary" href="https://calendly.com/titan-solutions-advisory/discovery">
+          <a class="btn btn--primary" href="https://outlook.office365.com/owa/calendar/Advisory@titansolutions.com.au/bookings/">
             Book a Free 15-Min Call
             <svg class="btn__arrow" viewBox="0 0 18 18" fill="none" aria-hidden="true">
               <path d="M3 9h12M10 4l5 5-5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
### Motivation
- Replace embedded Calendly booking URLs with the organisation's Microsoft Bookings URL so the site points to the new booking system.

### Description
- Replaced two `href` values in `index.html` from `https://calendly.com/titan-solutions-advisory/discovery` to `https://outlook.office365.com/owa/calendar/Advisory@titansolutions.com.au/bookings/` and did not modify any other text, styling, or layout.
- Only `index.html` was modified and both booking CTA anchors were updated.
- Commit message used: `Replace Calendly link with Microsoft Bookings link`.

### Testing
- Ran a search for Calendly references with `rg` which initially found two matches in `index.html`, and verified after the change there were no `calendly` matches and two `outlook.office365.com/.../bookings/` matches.
- Wrote the replacement and committed with `git commit` which succeeded and produced one commit for `index.html`.
- Attempted `git push origin HEAD:main` which failed because the `origin` remote is not configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58eca3c30832e95f4390f915148ea)