### PR TITLE
Fix booking link to Microsoft Bookings

### DIFF
--- a/index.html
+++ b/index.html
@@ -706,7 +706,7 @@
         <span class="brand-lockup__divider" aria-hidden="true"></span>
         <span class="brand-lockup__advisory">Advisory</span>
       </a>
-      <a class="header-cta" href="#book" aria-label="Book a free 15-minute call">
+      <a class="header-cta" href="https://outlook.office365.com/owa/calendar/Advisory@titansolutions.com.au/bookings/" aria-label="Book a free 15-minute call">
         Book a 15-min call
         <svg class="header-cta__arrow" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
           <path d="M2 7h10M8 3l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
### Motivation
- Replace legacy internal booking anchor/URL so site booking CTAs open the Microsoft Bookings flow without altering layout or styling.

### Description
- Replaced internal `#book` links with `https://outlook.office365.com/owa/calendar/Advisory@titansolutions.com.au/bookings/` in `index.html` and ensured booking CTAs point to the external bookings page; no styling, layout, or other content was modified; updated file: `index.html`.

### Testing
- Used `rg` to locate legacy links, applied a small Python replacement script which wrote the change to `index.html`, and re-ran `rg` to confirm only the Microsoft Bookings URL remains; these verification steps succeeded.
- Attempt to push to the remote failed because no `origin` remote is configured in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59183ba98832e881f597fa4e4205a)