### PR TITLE
Privacy policy: swap header logo and match footer background to site

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -150,6 +150,7 @@
   .contact-line a { font-weight: 700; }
 
   .site-footer {
+    background: var(--paper-deep);
     border-top: 1px solid var(--rule);
     padding: 28px 0 36px;
     color: var(--ink-3);
@@ -173,7 +174,7 @@
 <header class="site-header" role="banner">
   <div class="container site-header__inner">
     <a class="brand-lockup" href="index.html" aria-label="Titan Solutions home">
-      <img src="assets/Titan-Solutions-Horizontal-Dark-Final.svg" alt="Titan Solutions" />
+      <img src="assets/Titan-Solutions-Horizontal.svg" alt="Titan Solutions" />
       <span class="brand-lockup__divider" aria-hidden="true"></span>
       <span class="brand-lockup__advisory">Advisory</span>
     </a>


### PR DESCRIPTION
### Motivation
- Align the Privacy Policy page with the main site branding by using the standard horizontal logo and matching the footer tone.

### Description
- Replaced the header logo in `privacy-policy.html` from `assets/Titan-Solutions-Horizontal-Dark-Final.svg` to `assets/Titan-Solutions-Horizontal.svg`.
- Added `background: var(--paper-deep);` to the `.site-footer` rules in `privacy-policy.html` so the footer colour matches `index.html`.

### Testing
- Verified via a local diff that only `privacy-policy.html` was modified and the updated file was saved successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1fa25dd0832eab4a13554adac4be)