### PR TITLE
Add Terms & Conditions page (derived from privacy-policy template)

### DIFF
--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en-AU">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Terms & Conditions — Titan Solutions</title>
+<link rel="icon" type="image/svg+xml" href="assets/Titan-Solutions-Icon.svg" />
+<link rel="stylesheet" href="colors_and_type.css" />
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; scroll-padding-top: 90px; }
+  body {
+    margin: 0;
+    font-family: var(--font-sans);
+    font-weight: 400;
+    color: var(--ink);
+    background: var(--paper);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: 1.6;
+  }
+
+  :root {
+    --paper: #F4F1EA;
+    --paper-deep: #ECE7DC;
+    --paper-card: #FBF9F4;
+    --ink: #14202E;
+    --ink-2: #2A3645;
+    --ink-3: #4A5566;
+    --ink-mute: #76808E;
+    --rule: #D8D2C4;
+    --rule-soft: #E5E0D2;
+    --accent: var(--titan-navy);
+    --accent-deep: var(--titan-navy-deep);
+    --accent-line: var(--titan-blue);
+    --max: 1180px;
+    --gutter: clamp(20px, 4vw, 56px);
+  }
+
+  .container { width: 100%; max-width: var(--max); margin: 0 auto; padding-left: var(--gutter); padding-right: var(--gutter); }
+
+  .skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: var(--accent-deep);
+    color: #fff;
+    padding: 0.6rem 0.9rem;
+    z-index: 100;
+  }
+  .skip-link:focus { left: 1rem; top: 1rem; }
+
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(244, 241, 234, 0.92);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+    border-bottom: 1px solid var(--rule-soft);
+  }
+  .site-header__inner { display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 72px; }
+  .brand-lockup { display: flex; align-items: center; gap: 12px; text-decoration: none; }
+  .brand-lockup img { height: 28px; width: auto; }
+  .brand-lockup__divider { width: 1px; height: 22px; background: var(--rule); }
+  .brand-lockup__advisory {
+    font-family: var(--font-display-alt), var(--font-sans);
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    font-weight: 700;
+  }
+  .header-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--accent-deep);
+    text-decoration: none;
+    padding: 10px 16px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-xs);
+  }
+
+  .page-hero { padding: clamp(56px, 9vw, 88px) 0 clamp(42px, 6vw, 58px); border-bottom: 1px solid var(--rule); }
+  .eyebrow {
+    font-family: var(--font-display-alt), var(--font-sans);
+    font-size: 12px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--ink-3);
+    margin: 0 0 24px;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .eyebrow::before { content: ""; width: 28px; height: 1px; background: var(--accent-line); }
+  .page-title {
+    margin: 0 0 14px;
+    font-size: clamp(36px, 5vw, 62px);
+    line-height: 1.08;
+    letter-spacing: -0.02em;
+    color: var(--ink);
+  }
+  .page-subtitle { margin: 0; max-width: 720px; color: var(--ink-3); font-size: clamp(17px, 2.1vw, 21px); }
+  .page-meta { margin-top: 20px; font-size: 14px; color: var(--ink-mute); }
+
+  .doc { padding: clamp(48px, 7vw, 84px) 0 clamp(72px, 9vw, 110px); }
+  .doc-wrap { max-width: 820px; }
+  .doc-intro {
+    border-left: 3px solid var(--accent-line);
+    background: var(--paper-card);
+    border: 1px solid var(--rule-soft);
+    border-left-width: 3px;
+    padding: 24px;
+    margin-bottom: 38px;
+  }
+  .doc-intro p { margin: 0 0 12px; color: var(--ink-2); }
+  .doc-intro p:last-child { margin-bottom: 0; }
+
+  h2 {
+    margin: 40px 0 12px;
+    font-size: clamp(24px, 3vw, 31px);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    scroll-margin-top: 104px;
+  }
+  p, li { font-size: 17px; line-height: 1.75; color: var(--ink-2); }
+  p { margin: 0 0 14px; }
+
+  ul { margin: 0 0 16px 0; padding: 0; list-style: none; }
+  li { position: relative; padding-left: 20px; margin-bottom: 8px; }
+  li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.84em;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-line);
+  }
+
+  a { color: var(--accent-deep); text-decoration: underline; text-decoration-color: rgba(44,90,160,0.5); text-underline-offset: 3px; }
+  a:hover { text-decoration-color: var(--accent-deep); }
+  .contact-line a { font-weight: 700; }
+
+  .site-footer {
+    background: var(--paper-deep);
+    border-top: 1px solid var(--rule);
+    padding: 28px 0 36px;
+    color: var(--ink-3);
+    font-size: 14px;
+  }
+  .site-footer__row { display: flex; justify-content: space-between; gap: 14px; flex-wrap: wrap; }
+
+  a:focus-visible, button:focus-visible { outline: 3px solid var(--titan-focus); outline-offset: 2px; }
+
+  @media (max-width: 640px) {
+    .site-header__inner { min-height: 64px; }
+    .brand-lockup__advisory { display: none; }
+    .brand-lockup__divider { display: none; }
+    p, li { font-size: 16px; }
+    .doc-intro { padding: 18px; }
+  }
+</style>
+</head>
+<body data-screen-label="Terms & Conditions">
+<a class="skip-link" href="#content">Skip to content</a>
+<header class="site-header" role="banner">
+  <div class="container site-header__inner">
+    <a class="brand-lockup" href="index.html" aria-label="Titan Solutions home">
+      <img src="assets/Titan-Solutions-Horizontal.svg" alt="Titan Solutions" />
+      <span class="brand-lockup__divider" aria-hidden="true"></span>
+      <span class="brand-lockup__advisory">Advisory</span>
+    </a>
+    <a class="header-cta" href="index.html#contact">Book Intro Call</a>
+  </div>
+</header>
+<main id="content">
+  <section class="page-hero" aria-labelledby="page-title">
+    <div class="container">
+      <span class="eyebrow">Legal</span>
+      <h1 id="page-title" class="page-title">Terms &amp; Conditions</h1>
+      <p class="page-subtitle">These Terms &amp; Conditions govern the use of the Titan Solutions website and the provision of advisory and consulting services by Titan Solutions.</p>
+      <p class="page-meta">Last updated: [Date]</p>
+    </div>
+  </section>
+  <article class="doc">
+    <div class="container doc-wrap">
+      <div class="doc-intro">
+        <p>These Terms &amp; Conditions govern the use of the Titan Solutions website and the provision of advisory and consulting services by Titan Solutions.</p>
+        <p>By using this website or engaging Titan Solutions for services, you agree to be bound by these Terms &amp; Conditions.</p>
+      </div>
+      <section><h2>Services</h2><p>Titan Solutions provides independent IT advisory and consulting services, which may include:</p><ul><li>Technology and infrastructure reviews</li><li>Microsoft 365 and cloud advisory</li><li>Strategic IT guidance</li><li>Architecture and design recommendations</li><li>Written reports and recommendations</li><li>Workshops and consultation sessions</li></ul><p>Titan Solutions does not currently provide:</p><ul><li>Managed IT services</li><li>24/7 support</li><li>Service desk operations</li><li>Continuous monitoring</li><li>Guaranteed compliance certification</li><li>Guaranteed security outcomes</li></ul><p>Unless explicitly agreed in writing, services are advisory in nature only.</p></section>
+      <section><h2>Engagements and Scope</h2><p>Services are provided based on agreed proposals, quotations, or written scope discussions. Titan Solutions will endeavour to confirm the agreed scope in writing prior to commencement of any engagement.</p><p>Any changes to scope, additional work, or requested variations may require revised pricing, timelines, or separate agreements.</p><p>Titan Solutions reserves the right to decline work outside the agreed scope.</p></section>
+      <section><h2>Fees and Payment Terms</h2><p>Unless otherwise agreed in writing:</p><ul><li>Engagements are provided on a fixed-fee basis</li><li>A 50% deposit is required prior to commencement of work</li><li>The remaining 50% balance is payable upon completion and delivery of the agreed work</li><li>Invoices are payable within 14 days of issue unless otherwise specified</li></ul><p>Late payment may result in delays to delivery of services or the release of final deliverables.</p></section>
+      <section><h2>Client Responsibilities</h2><p>Clients are responsible for:</p><ul><li>Providing accurate and complete information</li><li>Reviewing recommendations prior to implementation</li><li>Maintaining appropriate backups and recovery processes</li><li>Obtaining any required vendor, licensing, or third-party approvals</li><li>Making final implementation and business decisions</li></ul><p>Titan Solutions relies on information provided by the client and is not responsible for issues arising from incomplete, inaccurate, or outdated information.</p></section>
+      <section><h2>Advisory Nature of Services</h2><p>All recommendations, guidance, and reports are provided in good faith based on information available at the time of engagement.</p><p>Technology environments, licensing models, vendor platforms, security threats, and compliance obligations can change over time.</p><p>Titan Solutions does not warrant or guarantee specific business outcomes, cost savings, or regulatory compliance, nor does it warrant platform availability or third-party vendor performance. Clients remain responsible for all operational, commercial, technical, and implementation decisions.</p></section>
+      <section><h2>Limitation of Liability</h2><p>Titan Solutions provides services in good faith and takes reasonable care in all engagements.</p><p>To the maximum extent permitted by law, Titan Solutions excludes liability for any indirect, incidental, consequential, or special loss or damage, including loss of profits, business interruption, loss of data, loss of revenue, or loss of opportunity.</p><p>Titan Solutions' total liability relating to any engagement is limited to the fees paid by the client for the specific services giving rise to the claim.</p><p>Nothing in these Terms excludes rights that cannot be excluded under Australian Consumer Law.</p></section>
+      <section><h2>Intellectual Property</h2><p>Unless otherwise agreed in writing, all intellectual property created by Titan Solutions remains the property of Titan Solutions. This includes reports, templates, methodologies, frameworks, documentation, and advisory materials.</p><p>Clients receive a perpetual, non-exclusive licence to use all delivered materials for their own internal business purposes. Clients may not reproduce, distribute, resell, or commercialise delivered materials without prior written permission.</p></section>
+      <section><h2>Confidentiality</h2><p>Titan Solutions treats all client information as confidential. A mutual non-disclosure agreement (NDA) is provided as standard at the commencement of every engagement, prior to any sensitive information being shared.</p><p>Titan Solutions will take reasonable steps to protect confidential information provided during engagements.</p><p>Clients acknowledge that electronic communication and cloud-based systems may involve inherent security risks despite reasonable safeguards being in place.</p></section>
+      <section><h2>Third-Party Services and Platforms</h2><p>Titan Solutions may utilise third-party platforms and cloud services including services provided by Microsoft and HubSpot.</p><p>Titan Solutions is not responsible for outages, failures, security incidents, or service interruptions caused by third-party providers.</p></section>
+      <section><h2>Website Use</h2><p>Information published on this website is general in nature and does not constitute formal professional, legal, financial, or security advice.</p><p>While reasonable care is taken to ensure information is accurate and current, Titan Solutions makes no guarantees regarding completeness, accuracy, or suitability.</p></section>
+      <section><h2>Privacy</h2><p>Titan Solutions handles personal information in accordance with its Privacy Policy. Please refer to the Privacy Policy published on this website for further information.</p></section>
+      <section><h2>Changes to Terms</h2><p>Titan Solutions may update these Terms &amp; Conditions from time to time. Updated versions will be published on this website and will take effect upon publication.</p></section>
+      <section><h2>Governing Law</h2><p>These Terms &amp; Conditions are governed by the laws of New South Wales, Australia. Any disputes arising in connection with these Terms will be subject to the jurisdiction of the courts of New South Wales.</p></section>
+      <section><h2>Contact</h2><p>For enquiries regarding these Terms &amp; Conditions, please contact:</p><p class="contact-line"><a href="mailto:advisory@titansolutions.com.au">advisory@titansolutions.com.au</a></p></section>
+    </div>
+  </article>
+</main>
+<footer class="site-footer" role="contentinfo">
+  <div class="container site-footer__row">
+    <span>© 2026 Titan Solutions. All rights reserved.</span>
+    <a href="index.html">Return to homepage</a>
+  </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated Terms & Conditions legal page that matches the existing site style and structure used for other legal pages. 
- Publish the supplied Terms & Conditions content (sections, bullet lists, and contact details) in a standalone HTML page for the website.

### Description
- Added a new file `terms-and-conditions.html` created from `privacy-policy.html` and preserved the same layout, inline styles, header/footer, and visual treatment. 
- Replaced page metadata and identifiers including the `<title>`, `data-screen-label`, hero heading, subtitle, and `Last updated: [Date]` placeholder. 
- Replaced the document body with the provided Terms & Conditions text and structured sections (Services, Engagements and Scope, Fees and Payment Terms, Client Responsibilities, Advisory Nature, Limitation of Liability, Intellectual Property, Confidentiality, Third-Party Services and Platforms, Website Use, Privacy, Changes to Terms, Governing Law, and Contact). 
- Kept all existing assets and CSS references intact and did not modify other repository files.

### Testing
- Confirmed the new file is present in the workspace using `rg --files`. 
- Inspected the generated HTML content with `sed -n` and `nl -ba` to verify the title, hero content, sections, and contact email were updated as expected. 
- All verification commands completed successfully and the produced `terms-and-conditions.html` contains the supplied Terms & Conditions content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb26033a44832e9580d3494c7c365b)